### PR TITLE
medical loadouts

### DIFF
--- a/cmf2_tvt120_EternalBabylon_v1.swu_public_salman_map/c/loadouts/common.hpp
+++ b/cmf2_tvt120_EternalBabylon_v1.swu_public_salman_map/c/loadouts/common.hpp
@@ -7,7 +7,7 @@
 
 // GEAR
 #define BASE_MEDICAL "ACE_elasticBandage:2","ACE_packingBandage:2","ACE_tourniquet:2","ACE_splint","kat_guedel","kat_chestSeal"
-#define MEDIC_MEDICAL "ACE_packingBandage:20","ACE_elasticBandage:20","ACE_splint:8","ACE_tourniquet:6","ACE_plasmaIV_500:4","kat_X_AED","kat_accuvac","kat_Pulseoximeter","kat_larynx","kat_aatKit","kat_guedel:5","kat_stethoscope","kat_chestSeal:2","kat_IO_FAST:2","kat_IV_16:6","ACE_morphine:8","ACE_epinephrine:8","ACE_adenosine:8","kat_Carbonate:4","kat_Painkiller:4","kat_nitroglycerin:4","kat_norepinephrine:4","kat_phenylephrine:4","kat_TXA:4","kat_atropine:4","kat_amiodarone:4","kat_naloxone:4","kat_lidocaine:4"
+#define MEDIC_MEDICAL "ACE_packingBandage:20","ACE_elasticBandage:20","ACE_splint:8","ACE_tourniquet:6","ACE_plasmaIV_500:4","ACE_salineIV_250:2","kat_X_AED","kat_accuvac","kat_Pulseoximeter","kat_larynx:5","kat_aatKit:6","kat_guedel:5","kat_stethoscope","kat_chestSeal:10","kat_IO_FAST:4","kat_IV_16:15","ACE_morphine:4","ACE_epinephrine:4","ACE_adenosine:4","kat_Carbonate:2","kat_Painkiller:2","kat_nitroglycerin:4","kat_norepinephrine:8","kat_phenylephrine:4","kat_TXA:8","kat_atropine:4","kat_amiodarone:4","kat_naloxone:4","kat_lidocaine:4","KAT_Empty_bloodIV_250:8"
 #define BASE_TOOLS "ACE_MapTools","ACE_IR_Strobe_item:2","ACE_Flashlight_XL50","ACE_SpraypaintRed","ACE_CableTie:2"
 #define BASE_LEADER_TOOLS "ACE_personalAidKit","ACE_Fortify"
 #define BASE_LINKED "ItemMap","ItemCompass","ItemWatch"


### PR DESCRIPTION
Keep in mind these are just on spawn. I still suggest providing medical crates so experienced medics can pick and choose. 
I decided to leave the AED, so medics can shock. However it is not the AED-X. So it does not monitor vitals itself. However the normal AED and a pulseOX weigh less. 

Obviously look this over and discuss. more eyes and suggestions = better loadouts. 

**ADDED**
 2x 250ml bags of saline - saline is required to clear IV obstructions otherwise I wouldnt bother.  (our normal loadout actually lack this as its new) 
 8x 250ml transfusion bags - because the idea of a medic who is waiting on more supplies needing to ask GI to donate blood is kinda neat. 

**INCREASED** 
count of King LTs to 5 - Always nice to have as many of these as possible in a mass cas
AAT kit count to 10 - AAT kits are single use items unless we change the settings.
chest seal count to 10 - 2 is a little rough. 10 may be overkill. Either way Im thinking of the new medics here.  
TXA count to 8 - TXA is handy when you have multiple wounded. 
norepinephrine count to 8 - To make up for slightly decreased epinephrine counts. 

**REDUCED**
morphine count by 4 - morphine is more dangerous in KAT. Hope making it more scarce will discourage ODs
painkiller count by 2 - Leaving 2 for total of 20 uses which is more than our normal sessions. 40 is still overkill and a waste of space.  
carbonate count by 2 - Same logic as painkillers.  20 is more than enough to wakeup a platoon if used right. 
epinephrine count to 4 - Mainly to prevent abusing it for a stamina boost. Provided more norepinephrine to fill the role without the cheese factor. However, epi also increases wakeup chance. Which norepi does not. 